### PR TITLE
Generic overload resolution

### DIFF
--- a/src/InlineIL.Fody/Model/MethodRefBuilder.cs
+++ b/src/InlineIL.Fody/Model/MethodRefBuilder.cs
@@ -70,12 +70,12 @@ namespace InlineIL.Fody.Model
                 case 0:
                     throw paramTypes == null
                         ? new WeavingException($"Method '{methodName}' not found in type {typeDef.FullName}")
-                        : new WeavingException($"Method {methodName}({string.Join(", ", paramTypes.Select(p => p.TryBuild(null)?.FullName ?? "???"))}) not found in type {typeDef.FullName}");
+                        : new WeavingException($"Method {methodName}({string.Join(", ", paramTypes.Select(p => p.GetDisplayName()))}) not found in type {typeDef.FullName}");
 
                 default:
                     throw paramTypes == null
                         ? new WeavingException($"Ambiguous method '{methodName}' in type {typeDef.FullName}")
-                        : new WeavingException($"Ambiguous method {methodName}({string.Join(", ", paramTypes.Select(p => p.TryBuild(null)?.FullName ?? "???"))}) in type {typeDef.FullName}");
+                        : new WeavingException($"Ambiguous method {methodName}({string.Join(", ", paramTypes.Select(p => p.GetDisplayName()))}) in type {typeDef.FullName}");
             }
         }
 

--- a/src/InlineIL.Fody/Model/TypeRefBuilder.cs
+++ b/src/InlineIL.Fody/Model/TypeRefBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Fody;
 using InlineIL.Fody.Extensions;
+using JetBrains.Annotations;
 using Mono.Cecil;
 using Mono.Cecil.Rocks;
 
@@ -13,7 +14,7 @@ namespace InlineIL.Fody.Model
         private readonly ModuleDefinition _module;
         private readonly List<TypeReference> _optionalModifiers = new List<TypeReference>();
         private readonly List<TypeReference> _requiredModifiers = new List<TypeReference>();
-        private TypeReference _typeRef;
+        private Func<IGenericParameterProvider, TypeReference> _typeRefProvider;
 
         public TypeRefBuilder(ModuleDefinition module, TypeReference typeRef)
         {
@@ -26,7 +27,8 @@ namespace InlineIL.Fody.Model
                 typeRef = typeRef.ResolveRequiredType();
             }
 
-            _typeRef = _module.ImportReference(typeRef);
+            typeRef = _module.ImportReference(typeRef);
+            _typeRefProvider = _ => typeRef;
         }
 
         public TypeRefBuilder(ModuleDefinition module, string assemblyName, string typeName)
@@ -53,9 +55,12 @@ namespace InlineIL.Fody.Model
             return typeRef;
         }
 
-        public TypeReference Build()
+        [CanBeNull]
+        public TypeReference TryBuild([CanBeNull] IGenericParameterProvider context)
         {
-            var type = _typeRef;
+            var type = _typeRefProvider(context);
+            if (type == null)
+                return null;
 
             foreach (var modifier in _optionalModifiers)
                 type = type.MakeOptionalModifierType(modifier);
@@ -66,59 +71,74 @@ namespace InlineIL.Fody.Model
             return type;
         }
 
+        public TypeReference Build()
+            => TryBuild(null) ?? throw new WeavingException("Cannot construct type reference");
+
         public void MakePointerType()
         {
-            EnsureCanWrapType();
+            WrapType(typeRef =>
+            {
+                EnsureCanWrapType(typeRef);
 
-            if (_typeRef.IsByReference)
-                throw new WeavingException("Cannot make a pointer to a ByRef type");
+                if (typeRef.IsByReference)
+                    throw new WeavingException("Cannot make a pointer to a ByRef type");
 
-            _typeRef = _module.ImportReference(_typeRef.MakePointerType());
+                return typeRef.MakePointerType();
+            });
         }
 
         public void MakeByRefType()
         {
-            EnsureCanWrapType();
+            WrapType(typeRef =>
+            {
+                EnsureCanWrapType(typeRef);
 
-            if (_typeRef.IsByReference)
-                throw new WeavingException("Type is already a ByRef type");
+                if (typeRef.IsByReference)
+                    throw new WeavingException("Type is already a ByRef type");
 
-            _typeRef = _module.ImportReference(_typeRef.MakeByReferenceType());
+                return typeRef.MakeByReferenceType();
+            });
         }
 
         public void MakeArrayType(int rank)
         {
-            EnsureCanWrapType();
+            WrapType(typeRef =>
+            {
+                EnsureCanWrapType(typeRef);
 
-            if (_typeRef.IsByReference)
-                throw new WeavingException("Cannot make an array of a ByRef type");
+                if (typeRef.IsByReference)
+                    throw new WeavingException("Cannot make an array of a ByRef type");
 
-            if (rank < 1)
-                throw new WeavingException($"Invalid array rank: {rank}, must be at least 1");
+                if (rank < 1)
+                    throw new WeavingException($"Invalid array rank: {rank}, must be at least 1");
 
-            _typeRef = _module.ImportReference(rank == 1 ? _typeRef.MakeArrayType() : _typeRef.MakeArrayType(rank));
+                return rank == 1 ? typeRef.MakeArrayType() : typeRef.MakeArrayType(rank);
+            });
         }
 
         public void MakeGenericType(TypeReference[] genericArgs)
         {
-            if (_typeRef.IsGenericInstance)
-                throw new WeavingException($"Type is already a generic instance: {_typeRef.FullName}");
+            WrapType(typeRef =>
+            {
+                if (typeRef.IsGenericInstance)
+                    throw new WeavingException($"Type is already a generic instance: {typeRef.FullName}");
 
-            if (_typeRef.IsByReference || _typeRef.IsPointer || _typeRef.IsArray)
-                throw new WeavingException("Cannot make a generic instance of a ByRef, pointer or array type");
+                if (typeRef.IsByReference || typeRef.IsPointer || typeRef.IsArray)
+                    throw new WeavingException("Cannot make a generic instance of a ByRef, pointer or array type");
 
-            var typeDef = _typeRef.ResolveRequiredType();
+                var typeDef = typeRef.ResolveRequiredType();
 
-            if (!typeDef.HasGenericParameters)
-                throw new WeavingException($"Not a generic type definition: {typeDef.FullName}");
+                if (!typeDef.HasGenericParameters)
+                    throw new WeavingException($"Not a generic type definition: {typeDef.FullName}");
 
-            if (genericArgs.Length == 0)
-                throw new WeavingException("No generic arguments supplied");
+                if (genericArgs.Length == 0)
+                    throw new WeavingException("No generic arguments supplied");
 
-            if (typeDef.GenericParameters.Count != genericArgs.Length)
-                throw new WeavingException($"Incorrect number of generic arguments supplied for type {typeDef.FullName} - expected {typeDef.GenericParameters.Count}, but got {genericArgs.Length}");
+                if (typeDef.GenericParameters.Count != genericArgs.Length)
+                    throw new WeavingException($"Incorrect number of generic arguments supplied for type {typeDef.FullName} - expected {typeDef.GenericParameters.Count}, but got {genericArgs.Length}");
 
-            _typeRef = _module.ImportReference(typeDef.MakeGenericInstanceType(genericArgs));
+                return typeDef.MakeGenericInstanceType(genericArgs);
+            });
         }
 
         public void AddOptionalModifier(TypeReference modifierType)
@@ -131,12 +151,20 @@ namespace InlineIL.Fody.Model
             _requiredModifiers.Add(modifierType);
         }
 
-        private void EnsureCanWrapType()
+        private void WrapType(Func<TypeReference, TypeReference> chainFunc)
         {
-            if (_typeRef.MetadataType == MetadataType.TypedByReference)
-                throw new WeavingException($"Cannot create an array, pointer or ByRef to {nameof(TypedReference)}");
+            var prevProvider = _typeRefProvider;
+            _typeRefProvider = context =>
+            {
+                var typeRef = prevProvider(context);
+                return typeRef != null ? _module.ImportReference(chainFunc(typeRef)) : null;
+            };
         }
 
-        public override string ToString() => _typeRef.ToString();
+        private static void EnsureCanWrapType(TypeReference typeRef)
+        {
+            if (typeRef.MetadataType == MetadataType.TypedByReference)
+                throw new WeavingException($"Cannot create an array, pointer or ByRef to {nameof(TypedReference)}");
+        }
     }
 }

--- a/src/InlineIL.Fody/Model/TypeRefBuilder.cs
+++ b/src/InlineIL.Fody/Model/TypeRefBuilder.cs
@@ -343,13 +343,11 @@ namespace InlineIL.Fody.Model
                 if (typeRef.IsByReference || typeRef.IsPointer || typeRef.IsArray)
                     throw new WeavingException("Cannot make a generic instance of a ByRef, pointer or array type");
 
-                var typeDef = typeRef.ResolveRequiredType();
+                if (!typeRef.HasGenericParameters)
+                    throw new WeavingException($"Not a generic type definition: {typeRef.FullName}");
 
-                if (!typeDef.HasGenericParameters)
-                    throw new WeavingException($"Not a generic type definition: {typeDef.FullName}");
-
-                if (typeDef.GenericParameters.Count != _genericArgs.Length)
-                    throw new WeavingException($"Incorrect number of generic arguments supplied for type {typeDef.FullName} - expected {typeDef.GenericParameters.Count}, but got {_genericArgs.Length}");
+                if (typeRef.GenericParameters.Count != _genericArgs.Length)
+                    throw new WeavingException($"Incorrect number of generic arguments supplied for type {typeRef.FullName} - expected {typeRef.GenericParameters.Count}, but got {_genericArgs.Length}");
 
                 var argTypeRefs = new TypeReference[_genericArgs.Length];
 

--- a/src/InlineIL.Fody/Model/TypeRefBuilder.cs
+++ b/src/InlineIL.Fody/Model/TypeRefBuilder.cs
@@ -169,7 +169,7 @@ namespace InlineIL.Fody.Model
                         if (_index >= context.GenericParameters.Count)
                             return null;
 
-                        return context.GenericParameters[_index];
+                        return module.ImportReference(context.GenericParameters[_index]);
                     }
 
                     case GenericParameterType.Method:
@@ -180,7 +180,7 @@ namespace InlineIL.Fody.Model
                         if (_index >= context.GenericParameters.Count)
                             return null;
 
-                        return context.GenericParameters[_index];
+                        return module.ImportReference(context.GenericParameters[_index]);
                     }
 
                     default:
@@ -372,7 +372,7 @@ namespace InlineIL.Fody.Model
                     argTypeRefs[i] = argTypeRef;
                 }
 
-                return module.ImportReference(typeDef.MakeGenericInstanceType(argTypeRefs));
+                return module.ImportReference(typeRef.MakeGenericInstanceType(argTypeRefs));
             }
 
             public override string GetDisplayName()

--- a/src/InlineIL.Fody/Processing/KnownNames.cs
+++ b/src/InlineIL.Fody/Processing/KnownNames.cs
@@ -13,6 +13,7 @@ namespace InlineIL.Fody.Processing
             public const string FieldRefType = "FieldRef";
             public const string LocalVarType = "LocalVar";
             public const string StandAloneMethodSigType = "StandAloneMethodSig";
+            public const string GenericParametersType = "GenericParameters";
 
             public const string PushMethod = "Push";
             public const string PopMethod = "Pop";
@@ -35,6 +36,7 @@ namespace InlineIL.Fody.Processing
             public const string FieldRefType = _nsPrefix + Short.FieldRefType;
             public const string LocalVarType = _nsPrefix + Short.LocalVarType;
             public const string StandAloneMethodSigType = _nsPrefix + Short.StandAloneMethodSigType;
+            public const string GenericParametersType = _nsPrefix + Short.GenericParametersType;
 
             public static readonly HashSet<string> AllTypes = new HashSet<string>
             {
@@ -44,7 +46,8 @@ namespace InlineIL.Fody.Processing
                 MethodRefType,
                 FieldRefType,
                 LocalVarType,
-                StandAloneMethodSigType
+                StandAloneMethodSigType,
+                GenericParametersType
             };
         }
     }

--- a/src/InlineIL.Fody/Processing/MethodWeaver.cs
+++ b/src/InlineIL.Fody/Processing/MethodWeaver.cs
@@ -844,7 +844,7 @@ namespace InlineIL.Fody.Processing
                 {
                     var args = instruction.GetArgumentPushInstructions();
                     var builder = ConsumeArgTypeRefBuilder(args[0]);
-                    var genericArgs = ConsumeArgArray(args[1], ConsumeArgTypeRef);
+                    var genericArgs = ConsumeArgArray(args[1], ConsumeArgTypeRefBuilder);
                     builder.MakeGenericType(genericArgs);
 
                     _il.Remove(instruction);

--- a/src/InlineIL.Fody/Processing/MethodWeaver.cs
+++ b/src/InlineIL.Fody/Processing/MethodWeaver.cs
@@ -886,7 +886,20 @@ namespace InlineIL.Fody.Processing
                         var typeRef = ConsumeArgTypeRef(args[0]);
                         var methodName = ConsumeArgString(args[1]);
                         var paramTypes = ConsumeArgArray(args[2], ConsumeArgTypeRef);
-                        var builder = MethodRefBuilder.MethodByNameAndSignature(Module, typeRef, methodName, paramTypes);
+                        var builder = MethodRefBuilder.MethodByNameAndSignature(Module, typeRef, methodName, null, paramTypes);
+
+                        _il.Remove(instruction);
+                        return builder;
+                    }
+
+                    case "System.Void InlineIL.MethodRef::.ctor(InlineIL.TypeRef,System.String,System.Int32,InlineIL.TypeRef[])":
+                    {
+                        var args = instruction.GetArgumentPushInstructions();
+                        var typeRef = ConsumeArgTypeRef(args[0]);
+                        var methodName = ConsumeArgString(args[1]);
+                        var genericParameterCount = ConsumeArgInt32(args[2]);
+                        var paramTypes = ConsumeArgArray(args[3], ConsumeArgTypeRef);
+                        var builder = MethodRefBuilder.MethodByNameAndSignature(Module, typeRef, methodName, genericParameterCount, paramTypes);
 
                         _il.Remove(instruction);
                         return builder;

--- a/src/InlineIL.Fody/Processing/MethodWeaver.cs
+++ b/src/InlineIL.Fody/Processing/MethodWeaver.cs
@@ -963,7 +963,7 @@ namespace InlineIL.Fody.Processing
                     {
                         var args = instruction.GetArgumentPushInstructions();
                         var typeRef = ConsumeArgTypeRef(args[0]);
-                        var paramTypes = ConsumeArgArray(args[1], ConsumeArgTypeRef);
+                        var paramTypes = ConsumeArgArray(args[1], ConsumeArgTypeRefBuilder);
                         var builder = MethodRefBuilder.Constructor(Module, typeRef, paramTypes);
 
                         _il.Remove(instruction);

--- a/src/InlineIL.Fody/Processing/MethodWeaver.cs
+++ b/src/InlineIL.Fody/Processing/MethodWeaver.cs
@@ -743,128 +743,127 @@ namespace InlineIL.Fody.Processing
 
         [NotNull]
         private TypeReference ConsumeArgTypeRef(Instruction typeRefInstruction)
+            => ConsumeArgTypeRefBuilder(typeRefInstruction).Build();
+
+        [NotNull]
+        private TypeRefBuilder ConsumeArgTypeRefBuilder(Instruction instruction)
         {
-            return ConsumeArgTypeRefBuilder(typeRefInstruction).Build();
+            if (instruction.OpCode.FlowControl != FlowControl.Call || !(instruction.Operand is MethodReference method))
+                throw UnexpectedInstruction(instruction, "a method call");
 
-            TypeRefBuilder ConsumeArgTypeRefBuilder(Instruction instruction)
+            switch (method.FullName)
             {
-                if (instruction.OpCode.FlowControl != FlowControl.Call || !(instruction.Operand is MethodReference method))
-                    throw UnexpectedInstruction(instruction, "a method call");
-
-                switch (method.FullName)
+                case "System.Type System.Type::GetTypeFromHandle(System.RuntimeTypeHandle)":
                 {
-                    case "System.Type System.Type::GetTypeFromHandle(System.RuntimeTypeHandle)":
-                    {
-                        var ldToken = instruction.GetArgumentPushInstructions().Single();
-                        if (ldToken.OpCode != OpCodes.Ldtoken)
-                            throw UnexpectedInstruction(ldToken, OpCodes.Ldtoken);
+                    var ldToken = instruction.GetArgumentPushInstructions().Single();
+                    if (ldToken.OpCode != OpCodes.Ldtoken)
+                        throw UnexpectedInstruction(ldToken, OpCodes.Ldtoken);
 
-                        var builder = new TypeRefBuilder(Module, (TypeReference)ldToken.Operand);
+                    var builder = new TypeRefBuilder(Module, (TypeReference)ldToken.Operand);
 
-                        _il.Remove(ldToken);
-                        _il.Remove(instruction);
-                        return builder;
-                    }
-
-                    case "InlineIL.TypeRef InlineIL.TypeRef::op_Implicit(System.Type)":
-                    case "System.Void InlineIL.TypeRef::.ctor(System.Type)":
-                    {
-                        var builder = ConsumeArgTypeRefBuilder(instruction.GetArgumentPushInstructions().Single());
-
-                        _il.Remove(instruction);
-                        return builder;
-                    }
-
-                    case "System.Void InlineIL.TypeRef::.ctor(System.String,System.String)":
-                    {
-                        var args = instruction.GetArgumentPushInstructions();
-                        var assemblyName = ConsumeArgString(args[0]);
-                        var typeName = ConsumeArgString(args[1]);
-                        var builder = new TypeRefBuilder(Module, assemblyName, typeName);
-
-                        _il.Remove(instruction);
-                        return builder;
-                    }
-
-                    case "InlineIL.TypeRef InlineIL.TypeRef::MakePointerType()":
-                    case "System.Type System.Type::MakePointerType()":
-                    {
-                        var builder = ConsumeArgTypeRefBuilder(instruction.GetArgumentPushInstructions().Single());
-                        builder.MakePointerType();
-
-                        _il.Remove(instruction);
-                        return builder;
-                    }
-
-                    case "InlineIL.TypeRef InlineIL.TypeRef::MakeByRefType()":
-                    case "System.Type System.Type::MakeByRefType()":
-                    {
-                        var builder = ConsumeArgTypeRefBuilder(instruction.GetArgumentPushInstructions().Single());
-                        builder.MakeByRefType();
-
-                        _il.Remove(instruction);
-                        return builder;
-                    }
-
-                    case "InlineIL.TypeRef InlineIL.TypeRef::MakeArrayType()":
-                    case "System.Type System.Type::MakeArrayType()":
-                    {
-                        var builder = ConsumeArgTypeRefBuilder(instruction.GetArgumentPushInstructions().Single());
-                        builder.MakeArrayType(1);
-
-                        _il.Remove(instruction);
-                        return builder;
-                    }
-
-                    case "InlineIL.TypeRef InlineIL.TypeRef::MakeArrayType(System.Int32)":
-                    case "System.Type System.Type::MakeArrayType(System.Int32)":
-                    {
-                        var args = instruction.GetArgumentPushInstructions();
-                        var builder = ConsumeArgTypeRefBuilder(args[0]);
-                        var rank = ConsumeArgInt32(args[1]);
-                        builder.MakeArrayType(rank);
-
-                        _il.Remove(instruction);
-                        return builder;
-                    }
-
-                    case "InlineIL.TypeRef InlineIL.TypeRef::MakeGenericType(InlineIL.TypeRef[])":
-                    case "System.Type System.Type::MakeGenericType(System.Type[])":
-                    {
-                        var args = instruction.GetArgumentPushInstructions();
-                        var builder = ConsumeArgTypeRefBuilder(args[0]);
-                        var genericArgs = ConsumeArgArray(args[1], ConsumeArgTypeRef);
-                        builder.MakeGenericType(genericArgs);
-
-                        _il.Remove(instruction);
-                        return builder;
-                    }
-
-                    case "InlineIL.TypeRef InlineIL.TypeRef::WithOptionalModifier(InlineIL.TypeRef)":
-                    {
-                        var args = instruction.GetArgumentPushInstructions();
-                        var builder = ConsumeArgTypeRefBuilder(args[0]);
-                        var modifierType = ConsumeArgTypeRef(args[1]);
-                        builder.AddOptionalModifier(modifierType);
-
-                        _il.Remove(instruction);
-                        return builder;
-                    }
-
-                    case "InlineIL.TypeRef InlineIL.TypeRef::WithRequiredModifier(InlineIL.TypeRef)":
-                    {
-                        var args = instruction.GetArgumentPushInstructions();
-                        var builder = ConsumeArgTypeRefBuilder(args[0]);
-                        var modifierType = ConsumeArgTypeRef(args[1]);
-                        builder.AddRequiredModifier(modifierType);
-
-                        _il.Remove(instruction);
-                        return builder;
-                    }
-
-                    default:
-                        throw UnexpectedInstruction(instruction, "a type reference");
+                    _il.Remove(ldToken);
+                    _il.Remove(instruction);
+                    return builder;
                 }
+
+                case "InlineIL.TypeRef InlineIL.TypeRef::op_Implicit(System.Type)":
+                case "System.Void InlineIL.TypeRef::.ctor(System.Type)":
+                {
+                    var builder = ConsumeArgTypeRefBuilder(instruction.GetArgumentPushInstructions().Single());
+
+                    _il.Remove(instruction);
+                    return builder;
+                }
+
+                case "System.Void InlineIL.TypeRef::.ctor(System.String,System.String)":
+                {
+                    var args = instruction.GetArgumentPushInstructions();
+                    var assemblyName = ConsumeArgString(args[0]);
+                    var typeName = ConsumeArgString(args[1]);
+                    var builder = new TypeRefBuilder(Module, assemblyName, typeName);
+
+                    _il.Remove(instruction);
+                    return builder;
+                }
+
+                case "InlineIL.TypeRef InlineIL.TypeRef::MakePointerType()":
+                case "System.Type System.Type::MakePointerType()":
+                {
+                    var builder = ConsumeArgTypeRefBuilder(instruction.GetArgumentPushInstructions().Single());
+                    builder.MakePointerType();
+
+                    _il.Remove(instruction);
+                    return builder;
+                }
+
+                case "InlineIL.TypeRef InlineIL.TypeRef::MakeByRefType()":
+                case "System.Type System.Type::MakeByRefType()":
+                {
+                    var builder = ConsumeArgTypeRefBuilder(instruction.GetArgumentPushInstructions().Single());
+                    builder.MakeByRefType();
+
+                    _il.Remove(instruction);
+                    return builder;
+                }
+
+                case "InlineIL.TypeRef InlineIL.TypeRef::MakeArrayType()":
+                case "System.Type System.Type::MakeArrayType()":
+                {
+                    var builder = ConsumeArgTypeRefBuilder(instruction.GetArgumentPushInstructions().Single());
+                    builder.MakeArrayType(1);
+
+                    _il.Remove(instruction);
+                    return builder;
+                }
+
+                case "InlineIL.TypeRef InlineIL.TypeRef::MakeArrayType(System.Int32)":
+                case "System.Type System.Type::MakeArrayType(System.Int32)":
+                {
+                    var args = instruction.GetArgumentPushInstructions();
+                    var builder = ConsumeArgTypeRefBuilder(args[0]);
+                    var rank = ConsumeArgInt32(args[1]);
+                    builder.MakeArrayType(rank);
+
+                    _il.Remove(instruction);
+                    return builder;
+                }
+
+                case "InlineIL.TypeRef InlineIL.TypeRef::MakeGenericType(InlineIL.TypeRef[])":
+                case "System.Type System.Type::MakeGenericType(System.Type[])":
+                {
+                    var args = instruction.GetArgumentPushInstructions();
+                    var builder = ConsumeArgTypeRefBuilder(args[0]);
+                    var genericArgs = ConsumeArgArray(args[1], ConsumeArgTypeRef);
+                    builder.MakeGenericType(genericArgs);
+
+                    _il.Remove(instruction);
+                    return builder;
+                }
+
+                case "InlineIL.TypeRef InlineIL.TypeRef::WithOptionalModifier(InlineIL.TypeRef)":
+                {
+                    var args = instruction.GetArgumentPushInstructions();
+                    var builder = ConsumeArgTypeRefBuilder(args[0]);
+                    var modifierType = ConsumeArgTypeRef(args[1]);
+                    builder.AddOptionalModifier(modifierType);
+
+                    _il.Remove(instruction);
+                    return builder;
+                }
+
+                case "InlineIL.TypeRef InlineIL.TypeRef::WithRequiredModifier(InlineIL.TypeRef)":
+                {
+                    var args = instruction.GetArgumentPushInstructions();
+                    var builder = ConsumeArgTypeRefBuilder(args[0]);
+                    var modifierType = ConsumeArgTypeRef(args[1]);
+                    builder.AddRequiredModifier(modifierType);
+
+                    _il.Remove(instruction);
+                    return builder;
+                }
+
+                default:
+                    throw UnexpectedInstruction(instruction, "a type reference");
             }
         }
 
@@ -885,7 +884,7 @@ namespace InlineIL.Fody.Processing
                         var args = instruction.GetArgumentPushInstructions();
                         var typeRef = ConsumeArgTypeRef(args[0]);
                         var methodName = ConsumeArgString(args[1]);
-                        var paramTypes = ConsumeArgArray(args[2], ConsumeArgTypeRef);
+                        var paramTypes = ConsumeArgArray(args[2], ConsumeArgTypeRefBuilder);
                         var builder = MethodRefBuilder.MethodByNameAndSignature(Module, typeRef, methodName, null, paramTypes);
 
                         _il.Remove(instruction);
@@ -898,7 +897,7 @@ namespace InlineIL.Fody.Processing
                         var typeRef = ConsumeArgTypeRef(args[0]);
                         var methodName = ConsumeArgString(args[1]);
                         var genericParameterCount = ConsumeArgInt32(args[2]);
-                        var paramTypes = ConsumeArgArray(args[3], ConsumeArgTypeRef);
+                        var paramTypes = ConsumeArgArray(args[3], ConsumeArgTypeRefBuilder);
                         var builder = MethodRefBuilder.MethodByNameAndSignature(Module, typeRef, methodName, genericParameterCount, paramTypes);
 
                         _il.Remove(instruction);

--- a/src/InlineIL.Tests.AssemblyToProcess/MethodRefTestCases.cs
+++ b/src/InlineIL.Tests.AssemblyToProcess/MethodRefTestCases.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using static InlineIL.IL.Emit;
@@ -7,6 +8,7 @@ namespace InlineIL.Tests.AssemblyToProcess
 {
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
     [SuppressMessage("ReSharper", "UnusedParameter.Local")]
+    [SuppressMessage("ReSharper", "UnusedTypeParameter")]
     public class MethodRefTestCases
     {
         public int Value { get; set; }
@@ -81,6 +83,82 @@ namespace InlineIL.Tests.AssemblyToProcess
 
             IL.Push(result);
             return IL.Return<int[]>();
+        }
+
+        public int[] ResolveGenericOverloads()
+        {
+            var result = new List<int>();
+            int item;
+
+            Ldc_I4_0();
+            Ldc_I4_0();
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericOverload), TypeRef.MethodGenericParameters[0], typeof(int)).MakeGenericMethod(typeof(int)));
+            IL.Pop(out item);
+            result.Add(item);
+
+            Ldc_I4_0();
+            Ldc_I4_0();
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericOverload), 1, TypeRef.MethodGenericParameters[0], typeof(uint)).MakeGenericMethod(typeof(int)));
+            IL.Pop(out item);
+            result.Add(item);
+
+            Ldc_I4_0();
+            Ldc_I4_0();
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericOverload), 2, TypeRef.MethodGenericParameters[0], typeof(uint)).MakeGenericMethod(typeof(int), typeof(int)));
+            IL.Pop(out item);
+            result.Add(item);
+
+            Ldc_I4_0();
+            Ldc_I4_0();
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericOverload), TypeRef.MethodGenericParameters[0], TypeRef.MethodGenericParameters[1]).MakeGenericMethod(typeof(int), typeof(int)));
+            IL.Pop(out item);
+            result.Add(item);
+
+            Ldc_I4_0();
+            Ldc_I4_0();
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericOverload), TypeRef.MethodGenericParameters[1], TypeRef.MethodGenericParameters[0]).MakeGenericMethod(typeof(int), typeof(int)));
+            IL.Pop(out item);
+            result.Add(item);
+
+            Ldc_I4_0();
+            Ldc_I4_0();
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericOverload), typeof(int), typeof(int)));
+            IL.Pop(out item);
+            result.Add(item);
+
+            Ldc_I4_0();
+            Ldc_I4_0();
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericOverload), 0, typeof(int), typeof(int)));
+            IL.Pop(out item);
+            result.Add(item);
+
+            return result.ToArray();
+        }
+
+        public int[] ResolveGenericOverloadsInGenericType()
+        {
+            var result = new List<int>();
+            int item;
+
+            Ldc_I4_0();
+            Ldc_I4_0();
+            Call(new MethodRef(typeof(GenericType<int>.NestedGenericType<int>), nameof(GenericType<int>.NestedGenericType<int>.GenericOverload), TypeRef.TypeGenericParameters[0], TypeRef.TypeGenericParameters[1]).MakeGenericMethod(typeof(int)));
+            IL.Pop(out item);
+            result.Add(item);
+
+            Ldc_I4_0();
+            Ldc_I4_0();
+            Call(new MethodRef(typeof(GenericType<int>.NestedGenericType<int>), nameof(GenericType<int>.NestedGenericType<int>.GenericOverload), TypeRef.TypeGenericParameters[1], TypeRef.TypeGenericParameters[0]).MakeGenericMethod(typeof(int)));
+            IL.Pop(out item);
+            result.Add(item);
+
+            Ldc_I4_0();
+            Ldc_I4_0();
+            Call(new MethodRef(typeof(GenericType<int>.NestedGenericType<int>), nameof(GenericType<int>.NestedGenericType<int>.GenericOverload), TypeRef.TypeGenericParameters[0], TypeRef.MethodGenericParameters[0]).MakeGenericMethod(typeof(int)));
+            IL.Pop(out item);
+            result.Add(item);
+
+            return result.ToArray();
         }
 
         public int CallGenericMethod()
@@ -191,15 +269,15 @@ namespace InlineIL.Tests.AssemblyToProcess
             => Event?.Invoke();
 
 #if NETFRAMEWORK
-    public int[] CallVarArgMethod()
-    {
-        IL.Push(5);
-        IL.Push(1);
-        IL.Push(2);
-        IL.Push(3);
-        IL.Emit.Call(new MethodRef(typeof(MethodRefTestCases), nameof(VarArgMethod)).WithOptionalParameters(typeof(int), typeof(int), typeof(int)));
-        return IL.Return<int[]>();
-    }
+        public int[] CallVarArgMethod()
+        {
+            IL.Push(5);
+            IL.Push(1);
+            IL.Push(2);
+            IL.Push(3);
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(VarArgMethod)).WithOptionalParameters(typeof(int), typeof(int), typeof(int)));
+            return IL.Return<int[]>();
+        }
 #endif
 
         private static int OverloadedMethod() => 10;
@@ -211,6 +289,13 @@ namespace InlineIL.Tests.AssemblyToProcess
 
         private static T GenericMethod<T>(T value) => value;
 
+        private static int GenericOverload<T>(T a, int b) => 1;
+        private static int GenericOverload<T>(T a, uint b) => 2;
+        private static int GenericOverload<T1, T2>(T1 a, uint b) => 3;
+        private static int GenericOverload<T1, T2>(T1 a, T2 b) => 4;
+        private static int GenericOverload<T1, T2>(T2 a, T1 b) => 5;
+        private static int GenericOverload(int a, int b) => 6;
+
         private class GenericType<TClass>
         {
             public static string NormalMethod()
@@ -218,19 +303,26 @@ namespace InlineIL.Tests.AssemblyToProcess
 
             public static string GenericMethod<TMethod>()
                 => $"{typeof(TClass).FullName} {typeof(TMethod).FullName}";
+
+            public class NestedGenericType<TOther>
+            {
+                public static int GenericOverload<T>(TClass a, TOther b) => 1;
+                public static int GenericOverload<T>(TOther a, TClass b) => 2;
+                public static int GenericOverload<T>(TClass a, T b) => 3;
+            }
         }
 
 #if NETFRAMEWORK
-    private static int[] VarArgMethod(int count, __arglist)
-    {
-        var it = new ArgIterator(__arglist);
-        var result = new int[count];
+        private static int[] VarArgMethod(int count, __arglist)
+        {
+            var it = new ArgIterator(__arglist);
+            var result = new int[count];
 
-        for (var i = 0; i < count; ++i)
-            result[i] = it.GetRemainingCount() > 0 ? __refvalue(it.GetNextArg(), int) : 0;
+            for (var i = 0; i < count; ++i)
+                result[i] = it.GetRemainingCount() > 0 ? __refvalue(it.GetNextArg(), int) : 0;
 
-        return result;
-    }
+            return result;
+        }
 #endif
 
         private class TypeWithInitializer

--- a/src/InlineIL.Tests.AssemblyToProcess/MethodRefTestCases.cs
+++ b/src/InlineIL.Tests.AssemblyToProcess/MethodRefTestCases.cs
@@ -132,6 +132,12 @@ namespace InlineIL.Tests.AssemblyToProcess
             IL.Pop(out item);
             result.Add(item);
 
+            Ldnull();
+            Ldnull();
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericOverload), TypeRef.MethodGenericParameters[0].MakeArrayType(), new TypeRef(typeof(List<>)).MakeGenericType(TypeRef.MethodGenericParameters[1])).MakeGenericMethod(typeof(int), typeof(int)));
+            IL.Pop(out item);
+            result.Add(item);
+
             return result.ToArray();
         }
 
@@ -155,6 +161,18 @@ namespace InlineIL.Tests.AssemblyToProcess
             Ldc_I4_0();
             Ldc_I4_0();
             Call(new MethodRef(typeof(GenericType<int>.NestedGenericType<int>), nameof(GenericType<int>.NestedGenericType<int>.GenericOverload), TypeRef.TypeGenericParameters[0], TypeRef.MethodGenericParameters[0]).MakeGenericMethod(typeof(int)));
+            IL.Pop(out item);
+            result.Add(item);
+
+            Ldnull();
+            Ldnull();
+            Call(new MethodRef(typeof(GenericType<int>.NestedGenericType<int>), nameof(GenericType<int>.NestedGenericType<int>.GenericOverload), TypeRef.TypeGenericParameters[0].MakeArrayType(), new TypeRef(typeof(List<>)).MakeGenericType(TypeRef.TypeGenericParameters[1])).MakeGenericMethod(typeof(int)));
+            IL.Pop(out item);
+            result.Add(item);
+
+            Ldnull();
+            Ldnull();
+            Call(new MethodRef(typeof(GenericType<int>.NestedGenericType<int>), nameof(GenericType<int>.NestedGenericType<int>.GenericOverload), TypeRef.MethodGenericParameters[0].MakeArrayType(), new TypeRef(typeof(List<>)).MakeGenericType(TypeRef.MethodGenericParameters[0])).MakeGenericMethod(typeof(int)));
             IL.Pop(out item);
             result.Add(item);
 
@@ -295,6 +313,7 @@ namespace InlineIL.Tests.AssemblyToProcess
         private static int GenericOverload<T1, T2>(T1 a, T2 b) => 4;
         private static int GenericOverload<T1, T2>(T2 a, T1 b) => 5;
         private static int GenericOverload(int a, int b) => 6;
+        private static int GenericOverload<T1, T2>(T1[] a, List<T2> b) => 7;
 
         private class GenericType<TClass>
         {
@@ -309,6 +328,8 @@ namespace InlineIL.Tests.AssemblyToProcess
                 public static int GenericOverload<T>(TClass a, TOther b) => 1;
                 public static int GenericOverload<T>(TOther a, TClass b) => 2;
                 public static int GenericOverload<T>(TClass a, T b) => 3;
+                public static int GenericOverload<T>(TClass[] a, List<TOther> b) => 4;
+                public static int GenericOverload<T>(T[] a, List<T> b) => 5;
             }
         }
 

--- a/src/InlineIL.Tests.AssemblyToProcess/TypeRefTestCases.cs
+++ b/src/InlineIL.Tests.AssemblyToProcess/TypeRefTestCases.cs
@@ -98,6 +98,12 @@ namespace InlineIL.Tests.AssemblyToProcess
             return IL.Return<RuntimeTypeHandle>();
         }
 
+        public RuntimeTypeHandle LoadGenericTypeByName()
+        {
+            Ldtoken(new TypeRef(TypeRef.CoreLibrary, "System.Action`1").MakeGenericType(typeof(int)));
+            return IL.Return<RuntimeTypeHandle>();
+        }
+
         public RuntimeTypeHandle LoadGenericTypeUsingType()
         {
             Ldtoken(typeof(Dictionary<,>).MakeGenericType(typeof(int), typeof(string)));

--- a/src/InlineIL.Tests.InvalidAssemblyToProcess/MethodRefTestCases.cs
+++ b/src/InlineIL.Tests.InvalidAssemblyToProcess/MethodRefTestCases.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using static InlineIL.IL.Emit;
 
@@ -62,6 +63,51 @@ namespace InlineIL.Tests.InvalidAssemblyToProcess
         public void TooManyGenericArgsProvided()
         {
             Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericMethod)).MakeGenericMethod(typeof(int), typeof(string)));
+        }
+
+        public void NoMatchingGenericOverload()
+        {
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericMethod), typeof(string)).MakeGenericMethod(typeof(int)));
+        }
+
+        public void TypeGenericArgOutsideOfGenericType()
+        {
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericMethod), TypeRef.TypeGenericParameters[42]).MakeGenericMethod(typeof(int)));
+        }
+
+        public void TypeGenericArgOutOfBounds()
+        {
+            Call(new MethodRef(typeof(GenericType<int>), nameof(GenericType<int>.Method), TypeRef.TypeGenericParameters[42]).MakeGenericMethod(typeof(int)));
+        }
+
+        public void MethodGenericArgOutOfBounds()
+        {
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericMethod), TypeRef.MethodGenericParameters[42]).MakeGenericMethod(typeof(int)));
+        }
+
+        public void NoMatchingGenericOverloadArray()
+        {
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericMethod), typeof(string).MakeArrayType()).MakeGenericMethod(typeof(int)));
+        }
+
+        public void NoMatchingGenericOverloadArray2()
+        {
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericMethod), typeof(string).MakeArrayType(2)).MakeGenericMethod(typeof(int)));
+        }
+
+        public void NoMatchingGenericOverloadByRef()
+        {
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericMethod), typeof(string).MakeByRefType()).MakeGenericMethod(typeof(int)));
+        }
+
+        public void NoMatchingGenericOverloadPointer()
+        {
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericMethod), typeof(int).MakePointerType()).MakeGenericMethod(typeof(int)));
+        }
+
+        public void NoMatchingGenericOverloadGeneric()
+        {
+            Call(new MethodRef(typeof(MethodRefTestCases), nameof(GenericMethod), typeof(Dictionary<,>).MakeGenericType(typeof(int), typeof(string))).MakeGenericMethod(typeof(int)));
         }
 
         public void NotAVarArgMethod()
@@ -133,6 +179,13 @@ namespace InlineIL.Tests.InvalidAssemblyToProcess
         private class ClassWithNoDefaultConstructor
         {
             public ClassWithNoDefaultConstructor(int foo)
+            {
+            }
+        }
+
+        private class GenericType<T>
+        {
+            public static void Method(T arg)
             {
             }
         }

--- a/src/InlineIL.Tests.InvalidAssemblyToProcess/TypeRefTestCases.cs
+++ b/src/InlineIL.Tests.InvalidAssemblyToProcess/TypeRefTestCases.cs
@@ -92,5 +92,20 @@ namespace InlineIL.Tests.InvalidAssemblyToProcess
         {
             Ldtoken(typeof(TypedReference).MakeByRefType());
         }
+
+        public void TypeGenericParameter()
+        {
+            Ldtoken(TypeRef.TypeGenericParameters[0]);
+        }
+
+        public void MethodGenericParameter()
+        {
+            Ldtoken(TypeRef.MethodGenericParameters[0]);
+        }
+
+        public void InvalidGenericParameterIndex()
+        {
+            Ldtoken(TypeRef.TypeGenericParameters[-1]);
+        }
     }
 }

--- a/src/InlineIL.Tests/Weaving/MethodRefTests.cs
+++ b/src/InlineIL.Tests/Weaving/MethodRefTests.cs
@@ -32,14 +32,14 @@ namespace InlineIL.Tests.Weaving
         public void should_resolve_generic_overloads()
         {
             var result = (int[])GetInstance().ResolveGenericOverloads();
-            result.ShouldEqual(new[] { 1, 2, 3, 4, 5, 6, 6 });
+            result.ShouldEqual(new[] { 1, 2, 3, 4, 5, 6, 6, 7 });
         }
 
         [Fact]
         public void should_resolve_generic_overloads_in_nested_generic_types()
         {
             var result = (int[])GetInstance().ResolveGenericOverloadsInGenericType();
-            result.ShouldEqual(new[] { 1, 2, 3 });
+            result.ShouldEqual(new[] { 1, 2, 3, 4, 5 });
         }
 
         [Fact]

--- a/src/InlineIL.Tests/Weaving/MethodRefTests.cs
+++ b/src/InlineIL.Tests/Weaving/MethodRefTests.cs
@@ -57,14 +57,14 @@ namespace InlineIL.Tests.Weaving
         }
 
         [Fact]
-        public void should_report_unknown_mehtod()
+        public void should_report_unknown_method()
         {
             ShouldHaveError("UnknownMethodWithoutParams").ShouldContain("Method 'Nope' not found");
             ShouldHaveError("UnknownMethodWithParams").ShouldContain("Method Nope(System.Int32) not found");
         }
 
         [Fact]
-        public void should_report_ambiguous_mehtod()
+        public void should_report_ambiguous_method()
         {
             ShouldHaveError("AmbiguousMethod").ShouldContain("Ambiguous method");
         }
@@ -221,6 +221,60 @@ namespace InlineIL.Tests.Weaving
         public void should_report_invalid_generic_args_count()
         {
             ShouldHaveError("TooManyGenericArgsProvided").ShouldContain("Incorrect number of generic arguments");
+        }
+
+        [Fact]
+        public void should_report_no_matching_generic_overload()
+        {
+            ShouldHaveError("NoMatchingGenericOverload").ShouldContain("Method GenericMethod(System.String) not found");
+        }
+
+        [Fact]
+        public void should_report_no_matching_generic_overload_with_type_generic_arg_outside_of_generic_type()
+        {
+            ShouldHaveError("TypeGenericArgOutsideOfGenericType").ShouldContain("Method GenericMethod(!42) not found");
+        }
+
+        [Fact]
+        public void should_report_no_matching_generic_overload_with_type_generic_arg_out_of_bounds()
+        {
+            ShouldHaveError("TypeGenericArgOutOfBounds").ShouldContain("Method Method(!42) not found");
+        }
+
+        [Fact]
+        public void should_report_no_matching_generic_overload_with_method_generic_arg_out_of_bounds()
+        {
+            ShouldHaveError("MethodGenericArgOutOfBounds").ShouldContain("Method GenericMethod(!!42) not found");
+        }
+
+        [Fact]
+        public void should_report_no_matching_generic_overload_with_constructed_array_type()
+        {
+            ShouldHaveError("NoMatchingGenericOverloadArray").ShouldContain("Method GenericMethod(System.String[]) not found");
+        }
+
+        [Fact]
+        public void should_report_no_matching_generic_overload_with_constructed_multi_dimensional_array_type()
+        {
+            ShouldHaveError("NoMatchingGenericOverloadArray2").ShouldContain("Method GenericMethod(System.String[,]) not found");
+        }
+
+        [Fact]
+        public void should_report_no_matching_generic_overload_with_constructed_by_ref_type()
+        {
+            ShouldHaveError("NoMatchingGenericOverloadByRef").ShouldContain("Method GenericMethod(System.String&) not found");
+        }
+
+        [Fact]
+        public void should_report_no_matching_generic_overload_with_constructed_pointer_type()
+        {
+            ShouldHaveError("NoMatchingGenericOverloadPointer").ShouldContain("Method GenericMethod(System.Int32*) not found");
+        }
+
+        [Fact]
+        public void should_report_no_matching_generic_overload_with_constructed_generic_type()
+        {
+            ShouldHaveError("NoMatchingGenericOverloadGeneric").ShouldContain("Method GenericMethod(System.Collections.Generic.Dictionary`2<System.Int32,System.String>) not found");
         }
 
 #if NETFRAMEWORK

--- a/src/InlineIL.Tests/Weaving/MethodRefTests.cs
+++ b/src/InlineIL.Tests/Weaving/MethodRefTests.cs
@@ -29,6 +29,20 @@ namespace InlineIL.Tests.Weaving
         }
 
         [Fact]
+        public void should_resolve_generic_overloads()
+        {
+            var result = (int[])GetInstance().ResolveGenericOverloads();
+            result.ShouldEqual(new[] { 1, 2, 3, 4, 5, 6, 6 });
+        }
+
+        [Fact]
+        public void should_resolve_generic_overloads_in_nested_generic_types()
+        {
+            var result = (int[])GetInstance().ResolveGenericOverloadsInGenericType();
+            result.ShouldEqual(new[] { 1, 2, 3 });
+        }
+
+        [Fact]
         public void should_resolve_overloads_unverifiable()
         {
             var result = (int[])GetUnverifiableInstance().ResolveOverloads();

--- a/src/InlineIL.Tests/Weaving/TypeRefTests.cs
+++ b/src/InlineIL.Tests/Weaving/TypeRefTests.cs
@@ -229,5 +229,23 @@ namespace InlineIL.Tests.Weaving
         {
             ShouldHaveError("ArrayOfTypedReference").ShouldContain("Cannot create an array, pointer or ByRef to TypedReference");
         }
+
+        [Fact]
+        public void should_report_incorrect_usage_of_type_generic_parameter()
+        {
+            ShouldHaveError("TypeGenericParameter").ShouldContain("TypeRef.TypeGenericParameters can only be used in MethodRef definitions for overload resolution");
+        }
+
+        [Fact]
+        public void should_report_incorrect_usage_of_method_generic_parameter()
+        {
+            ShouldHaveError("MethodGenericParameter").ShouldContain("TypeRef.MethodGenericParameters can only be used in MethodRef definitions for overload resolution");
+        }
+
+        [Fact]
+        public void should_report_invalid_generic_parameter_index()
+        {
+            ShouldHaveError("InvalidGenericParameterIndex").ShouldContain("Invalid generic parameter index");
+        }
     }
 }

--- a/src/InlineIL.Tests/Weaving/TypeRefTests.cs
+++ b/src/InlineIL.Tests/Weaving/TypeRefTests.cs
@@ -106,6 +106,13 @@ namespace InlineIL.Tests.Weaving
         }
 
         [Fact]
+        public void should_handle_generic_types_by_name()
+        {
+            var result = (RuntimeTypeHandle)GetInstance().LoadGenericTypeByName();
+            Type.GetTypeFromHandle(result).ShouldEqual(typeof(Action<int>));
+        }
+
+        [Fact]
         public void should_handle_nested_types_using_runtime_syntax()
         {
             var result = (Type)GetInstance().ReturnNestedTypeUsingRuntimeSyntax();

--- a/src/InlineIL/GenericParameters.cs
+++ b/src/InlineIL/GenericParameters.cs
@@ -1,0 +1,23 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace InlineIL
+{
+    /// <summary>
+    /// Represents a list of generic parameters. Use the indexer to retrieve a given parameter.
+    /// </summary>
+    [SuppressMessage("ReSharper", "ClassCannotBeInstantiated")]
+    [SuppressMessage("ReSharper", "ClassNeverInstantiated.Global")]
+    [SuppressMessage("ReSharper", "UnusedParameter.Global")]
+    public sealed class GenericParameters
+    {
+        private GenericParameters()
+            => IL.Throw();
+
+        /// <summary>
+        /// Gets the generic parameter type at the specified index.
+        /// </summary>
+        /// <param name="index">The index of the generic parameter type to get.</param>
+        public TypeRef this[int index]
+            => throw IL.Throw();
+    }
+}

--- a/src/InlineIL/MethodRef.cs
+++ b/src/InlineIL/MethodRef.cs
@@ -11,7 +11,7 @@ namespace InlineIL
     public sealed class MethodRef
     {
         /// <summary>
-        /// Constructs a method reference. If the method is overloaded, use <see cref="MethodRef(TypeRef, string, TypeRef[])" /> instead.
+        /// Constructs a method reference for a non-overloaded method.
         /// </summary>
         /// <param name="type">The type declaring the method.</param>
         /// <param name="methodName">The method name.</param>
@@ -19,12 +19,22 @@ namespace InlineIL
             => IL.Throw();
 
         /// <summary>
-        /// Constructs a method reference
+        /// Constructs a method reference.
         /// </summary>
         /// <param name="type">The type declaring the method.</param>
         /// <param name="methodName">The method name.</param>
         /// <param name="parameterTypes">The types of the method parameters.</param>
         public MethodRef(TypeRef type, string methodName, params TypeRef[] parameterTypes)
+            => IL.Throw();
+
+        /// <summary>
+        /// Constructs a method reference.
+        /// </summary>
+        /// <param name="type">The type declaring the method.</param>
+        /// <param name="methodName">The method name.</param>
+        /// <param name="genericParameterCount">The generic parameter count. Use 0 for a non-generic method.</param>
+        /// <param name="parameterTypes">The types of the method parameters.</param>
+        public MethodRef(TypeRef type, string methodName, int genericParameterCount, params TypeRef[] parameterTypes)
             => IL.Throw();
 
         /// <summary>

--- a/src/InlineIL/TypeRef.cs
+++ b/src/InlineIL/TypeRef.cs
@@ -18,6 +18,19 @@ namespace InlineIL
             => throw IL.Throw();
 
         /// <summary>
+        /// Generic parameters of the declaring type, for overload resolution.
+        /// Generic parameters of a nested type come after generic parameters of its enclosing type.
+        /// </summary>
+        public static GenericParameters TypeGenericParameters
+            => throw IL.Throw();
+
+        /// <summary>
+        /// Generic parameters of the method, for overload resolution.
+        /// </summary>
+        public static GenericParameters MethodGenericParameters
+            => throw IL.Throw();
+
+        /// <summary>
         /// Constructs a type reference from a <see cref="Type"/>.
         /// </summary>
         /// <param name="type">The type to reference.</param>


### PR DESCRIPTION
This adds new capabilities to overload resolution when generics are involved. Fixes #10.

New APIs:
 - `TypeRef.TypeGenericParameters[N]` to represent `!N`
 - `TypeRef.MethodGenericParameters[N]` to represent `!!N`
 - A new `MethodRef` constructor overload with an `int genericParameterCount` parameter in order to disambiguate between overloads which differ only by generic arity.

