### PR TITLE
Remove `unmanaged` constraint from generic pointers.

### DIFF
--- a/src/InlineIL/IL.cs
+++ b/src/InlineIL/IL.cs
@@ -122,9 +122,7 @@ public static unsafe partial class IL
     /// <param name="value">A reference to a local variable receiving the pointer.</param>
     public static void Pop<T>(out T* value)
 #if NET9_0_OR_GREATER
-        where T : unmanaged, allows ref struct
-#else
-        where T : unmanaged
+        where T : allows ref struct
 #endif
         => throw Throw();
 
@@ -187,9 +185,7 @@ public static unsafe partial class IL
     /// <returns>The pointer on top of the evaluation stack, which should be immediately returned from the method.</returns>
     public static T* ReturnPointer<T>()
 #if NET9_0_OR_GREATER
-        where T : unmanaged, allows ref struct
-#else
-        where T : unmanaged
+        where T : allows ref struct
 #endif
         => throw Throw();
 

--- a/src/InlineIL/InlineIL.csproj
+++ b/src/InlineIL/InlineIL.csproj
@@ -13,6 +13,7 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <DefineConstants>$(DefineConstants);INLINEIL_LIBRARY</DefineConstants>
+    <NoWarn>$(NoWarn);CS8500</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since C# 11 pointers to managed types are allowed but with a warning. This PR removes the `unmanaged` constraint from `IL.Pop` and `ReturnPointer`, and suppresses the warning.